### PR TITLE
Don't build event library for each project that uses it

### DIFF
--- a/ConsumerProducer/Makefile
+++ b/ConsumerProducer/Makefile
@@ -34,7 +34,7 @@ TST_DEP_FILES := $(TST_CPP_FILES:$(TST_SRC_DIR)/%.cpp=$(INT_DIR)/%.d)
 TST_BIN_TARGETS = $(TST_CPP_FILES:$(TST_SRC_DIR)/%.cpp=$(TST_BIN_DIR)/%)
 TST_RESULTS = $(TST_CPP_FILES:$(TST_SRC_DIR)/%.cpp=$(INT_DIR)/%.passed)
 
-DEP_FLAGS = -MT $@ -MMD -MP -MF $(INT_DIR)/$*.d -iquote "."
+DEP_FLAGS = -MT $@ -MMD -MP -MF $(INT_DIR)/$*.d -iquote "." -iquote "../Event"
 STD_FLAGS = --std=c++17 -pthread -fno-rtti
 WARN_FLAGS = -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wpedantic -Werror
 

--- a/ConsumerProducer/Makefile
+++ b/ConsumerProducer/Makefile
@@ -11,6 +11,7 @@
 APP_SRC_DIR = app
 LIB_SRC_DIR = lib
 TST_SRC_DIR = tst
+EVENT_SRC_DIR = ../Event/lib
 
 INT_DIR = int
 
@@ -25,6 +26,10 @@ APP_DEP_FILES := $(APP_CPP_FILES:$(APP_SRC_DIR)/%.cpp=$(INT_DIR)/%.d)
 LIB_CPP_FILES := $(shell find $(LIB_SRC_DIR) -name '*.cpp')
 LIB_OBJ_FILES := $(LIB_CPP_FILES:$(LIB_SRC_DIR)/%.cpp=$(INT_DIR)/%.o)
 LIB_DEP_FILES := $(LIB_CPP_FILES:$(LIB_SRC_DIR)/%.cpp=$(INT_DIR)/%.d)
+
+EVENT_CPP_FILES := $(shell find $(EVENT_SRC_DIR) -name '*.cpp')
+EVENT_OBJ_FILES := $(EVENT_CPP_FILES:$(EVENT_SRC_DIR)/%.cpp=$(INT_DIR)/%.o)
+EVENT_DEP_FILES := $(EVENT_CPP_FILES:$(EVENT_SRC_DIR)/%.cpp=$(INT_DIR)/%.d)
 
 TST_BIN_DIR = $(BIN_DIR)/tst
 
@@ -74,7 +79,10 @@ $(APP_OBJ_FILES): $(INT_DIR)/%.o: $(APP_SRC_DIR)/%.cpp $(INT_DIR)/%.d | $(INT_DI
 $(LIB_OBJ_FILES): $(INT_DIR)/%.o: $(LIB_SRC_DIR)/%.cpp $(INT_DIR)/%.d | $(INT_DIR)
 	$(CXX) $(CXXFLAGS) -c -o $@ $<
 
-$(BIN_TARGET): $(APP_OBJ_FILES) $(LIB_OBJ_FILES) | $(BIN_DIR)
+$(EVENT_OBJ_FILES): $(INT_DIR)/%.o: $(EVENT_SRC_DIR)/%.cpp $(INT_DIR)/%.d | $(INT_DIR)
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
+
+$(BIN_TARGET): $(APP_OBJ_FILES) $(LIB_OBJ_FILES) $(EVENT_OBJ_FILES) | $(BIN_DIR)
 	$(CXX) $(LDFLAGS) -o $@ $^
 
 $(TST_OBJ_FILES): $(INT_DIR)/%.o: $(TST_SRC_DIR)/%.cpp $(INT_DIR)/%.d | $(INT_DIR)
@@ -89,10 +97,12 @@ $(TST_RESULTS) : $(INT_DIR)/%.passed: $(TST_BIN_DIR)/%
 
 $(APP_DEP_FILES): $(INT_DIR)/%.d: ;
 $(LIB_DEP_FILES): $(INT_DIR)/%.d: ;
+$(EVENT_DEP_FILES): $(INT_DIR)/%.d: ;
 $(TST_DEP_FILES): $(INT_DIR)/%.d: ;
 
 -include $(APP_DEP_FILES)
 -include $(LIB_DEP_FILES)
+-include $(EVENT_DEP_FILES)
 -include $(TST_DEP_FILES)
 
 $(INT_DIR):

--- a/ConsumerProducer/WORKSPACE
+++ b/ConsumerProducer/WORKSPACE
@@ -5,3 +5,8 @@ git_repository(
     remote = "https://github.com/google/googletest",
     tag = "release-1.10.0",
 )
+
+local_repository(
+    name = "event",
+    path = "../Event",
+)

--- a/ConsumerProducer/lib/BUILD
+++ b/ConsumerProducer/lib/BUILD
@@ -9,14 +9,3 @@ cc_library(
     ],
     visibility = ["//:__subpackages__"],
 )
-
-cc_library(
-    name = "event",
-    srcs = [
-        "event.cpp",
-    ],
-    hdrs = [
-        "event.h",
-    ],
-    visibility = ["//:__subpackages__"],
-)

--- a/ConsumerProducer/lib/event.cpp
+++ b/ConsumerProducer/lib/event.cpp
@@ -1,1 +1,0 @@
-../../Event/lib/event.cpp

--- a/ConsumerProducer/lib/event.h
+++ b/ConsumerProducer/lib/event.h
@@ -1,1 +1,0 @@
-../../Event/lib/event.h

--- a/ConsumerProducer/tst/BUILD
+++ b/ConsumerProducer/tst/BUILD
@@ -10,7 +10,7 @@ cc_test(
     ],
     deps = [
         "//lib:consumer",
-        "//lib:event",
+        "@event//lib:event",
         "@googletest//:gtest_main",
     ],
 )

--- a/Event/lib/BUILD
+++ b/Event/lib/BUILD
@@ -8,5 +8,5 @@ cc_library(
     hdrs = [
         "event.h",
     ],
-    visibility = ["//:__subpackages__"],
+    visibility = ["//visibility:public"],
 )

--- a/SharedPtr/Makefile
+++ b/SharedPtr/Makefile
@@ -34,7 +34,7 @@ TST_DEP_FILES := $(TST_CPP_FILES:$(TST_SRC_DIR)/%.cpp=$(INT_DIR)/%.d)
 TST_BIN_TARGETS = $(TST_CPP_FILES:$(TST_SRC_DIR)/%.cpp=$(TST_BIN_DIR)/%)
 TST_RESULTS = $(TST_CPP_FILES:$(TST_SRC_DIR)/%.cpp=$(INT_DIR)/%.passed)
 
-DEP_FLAGS = -MT $@ -MMD -MP -MF $(INT_DIR)/$*.d -iquote "."
+DEP_FLAGS = -MT $@ -MMD -MP -MF $(INT_DIR)/$*.d -iquote "." -iquote "../Event"
 STD_FLAGS = --std=c++17 -pthread -fno-rtti
 WARN_FLAGS = -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wpedantic -Werror
 

--- a/SharedPtr/Makefile
+++ b/SharedPtr/Makefile
@@ -11,6 +11,7 @@
 APP_SRC_DIR = app
 LIB_SRC_DIR = lib
 TST_SRC_DIR = tst
+EVENT_SRC_DIR = ../Event/lib
 
 INT_DIR = int
 
@@ -25,6 +26,10 @@ APP_DEP_FILES := $(APP_CPP_FILES:$(APP_SRC_DIR)/%.cpp=$(INT_DIR)/%.d)
 LIB_CPP_FILES := $(shell find $(LIB_SRC_DIR) -name '*.cpp')
 LIB_OBJ_FILES := $(LIB_CPP_FILES:$(LIB_SRC_DIR)/%.cpp=$(INT_DIR)/%.o)
 LIB_DEP_FILES := $(LIB_CPP_FILES:$(LIB_SRC_DIR)/%.cpp=$(INT_DIR)/%.d)
+
+EVENT_CPP_FILES := $(shell find $(EVENT_SRC_DIR) -name '*.cpp')
+EVENT_OBJ_FILES := $(EVENT_CPP_FILES:$(EVENT_SRC_DIR)/%.cpp=$(INT_DIR)/%.o)
+EVENT_DEP_FILES := $(EVENT_CPP_FILES:$(EVENT_SRC_DIR)/%.cpp=$(INT_DIR)/%.d)
 
 TST_BIN_DIR = $(BIN_DIR)/tst
 
@@ -74,7 +79,10 @@ $(APP_OBJ_FILES): $(INT_DIR)/%.o: $(APP_SRC_DIR)/%.cpp $(INT_DIR)/%.d | $(INT_DI
 $(LIB_OBJ_FILES): $(INT_DIR)/%.o: $(LIB_SRC_DIR)/%.cpp $(INT_DIR)/%.d | $(INT_DIR)
 	$(CXX) $(CXXFLAGS) -c -o $@ $<
 
-$(BIN_TARGET): $(APP_OBJ_FILES) $(LIB_OBJ_FILES) | $(BIN_DIR)
+$(EVENT_OBJ_FILES): $(INT_DIR)/%.o: $(EVENT_SRC_DIR)/%.cpp $(INT_DIR)/%.d | $(INT_DIR)
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
+
+$(BIN_TARGET): $(APP_OBJ_FILES) $(LIB_OBJ_FILES) $(EVENT_OBJ_FILES) | $(BIN_DIR)
 	$(CXX) $(LDFLAGS) -o $@ $^
 
 $(TST_OBJ_FILES): $(INT_DIR)/%.o: $(TST_SRC_DIR)/%.cpp $(INT_DIR)/%.d | $(INT_DIR)
@@ -89,10 +97,12 @@ $(TST_RESULTS) : $(INT_DIR)/%.passed: $(TST_BIN_DIR)/%
 
 $(APP_DEP_FILES): $(INT_DIR)/%.d: ;
 $(LIB_DEP_FILES): $(INT_DIR)/%.d: ;
+$(EVENT_DEP_FILES): $(INT_DIR)/%.d: ;
 $(TST_DEP_FILES): $(INT_DIR)/%.d: ;
 
 -include $(APP_DEP_FILES)
 -include $(LIB_DEP_FILES)
+-include $(EVENT_DEP_FILES)
 -include $(TST_DEP_FILES)
 
 $(INT_DIR):

--- a/SharedPtr/WORKSPACE
+++ b/SharedPtr/WORKSPACE
@@ -5,3 +5,8 @@ git_repository(
     remote = "https://github.com/google/googletest",
     tag = "release-1.10.0",
 )
+
+local_repository(
+    name = "event",
+    path = "../Event",
+)

--- a/SharedPtr/app/BUILD
+++ b/SharedPtr/app/BUILD
@@ -6,7 +6,7 @@ cc_binary(
         "main.cpp",
     ],
     deps = [
-        "//lib:event",
         "//lib:shared_ptr",
+        "@event//lib:event",
     ],
 )

--- a/SharedPtr/lib/BUILD
+++ b/SharedPtr/lib/BUILD
@@ -1,17 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
-    name = "event",
-    srcs = [
-        "event.cpp",
-    ],
-    hdrs = [
-        "event.h",
-    ],
-    visibility = ["//:__subpackages__"],
-)
-
-cc_library(
     name = "shared_ptr",
     srcs = [
         "shared_ptr.cpp",
@@ -20,7 +9,7 @@ cc_library(
         "shared_ptr.h",
     ],
     deps = [
-        ":event",
+        "@event//lib:event",
     ],
     visibility = ["//:__subpackages__"],
 )

--- a/SharedPtr/lib/event.cpp
+++ b/SharedPtr/lib/event.cpp
@@ -1,1 +1,0 @@
-../../Event/lib/event.cpp

--- a/SharedPtr/lib/event.h
+++ b/SharedPtr/lib/event.h
@@ -1,1 +1,0 @@
-../../Event/lib/event.h


### PR DESCRIPTION
* For Bazel, share the workspace.
* For Makefile, continue building in each project for now (but don't link the files, share the originals).